### PR TITLE
Add an option to allow for webkit to handle download requests

### DIFF
--- a/surf.1
+++ b/surf.1
@@ -79,6 +79,12 @@ Disable kiosk mode (disable key strokes and right click).
 .B \-K
 Enable kiosk mode (disable key strokes and right click).
 .TP
+.B \-l
+Disable curl downloads. Let webkit handle downloads internally.
+.TP
+.B \-L
+Enable curl downloads by spawning a virtual terminal with curl.
+.TP
 .B \-m
 Disable application of user style sheets.
 .TP


### PR DESCRIPTION
Added -l/-L options that disable/enable download to be handled internally by webkit instead of by spawning curl.